### PR TITLE
change comment format to avoid "discarded extraneous zeekygen comment" warnings

### DIFF
--- a/scripts/ge_srtp_enums.zeek
+++ b/scripts/ge_srtp_enums.zeek
@@ -1,4 +1,4 @@
-## Copyright (c) 2024 Battelle Energy Alliance, LLC. 
+##! Copyright (c) 2024 Battelle Energy Alliance, LLC.
 
 module GE_SRTP_ENUMS;
 

--- a/scripts/ge_srtp_processing.zeek
+++ b/scripts/ge_srtp_processing.zeek
@@ -1,4 +1,4 @@
-## Copyright (c) 2024 Battelle Energy Alliance, LLC. 
+##! Copyright (c) 2024 Battelle Energy Alliance, LLC.
 
 module GE_SRTP;
 

--- a/scripts/ge_srtp_types.zeek
+++ b/scripts/ge_srtp_types.zeek
@@ -1,4 +1,4 @@
-## Copyright (c) 2024 Battelle Energy Alliance, LLC. 
+##! Copyright (c) 2024 Battelle Energy Alliance, LLC.
 
 module GE_SRTP;
 

--- a/scripts/main.zeek
+++ b/scripts/main.zeek
@@ -1,13 +1,12 @@
-## Copyright (c) 2024 Battelle Energy Alliance, LLC. 
+##! Copyright (c) 2024 Battelle Energy Alliance, LLC.
+##!
+##! main.zeek
+##!
+##! ICSNPP-GE_SRTP
+##!
+##! Zeek script type/record definitions describing the information
+##! that will be written to the log files.
 
-##
-## main.zeek
-##
-## ICSNPP-GE_SRTP
-##
-## Zeek script type/record definitions describing the information
-## that will be written to the log files.
-##
 
 module GE_SRTP;
 


### PR DESCRIPTION
Changed some double-pound comments to double-pound-bash comments to avoid 'discarded extraneous zeekygen comment' warning, see [zeekygen/example.zeek](https://github.com/zeek/zeek/blob/master/scripts/zeekygen/example.zeek) for reference.

Every time I run zeek with this script installed, we see something like this warning:

```
warning in ..., line 1: Discarded extraneous Zeekygen comment: profinet_io_processing.zeek
warning in ..., line 1: Discarded extraneous Zeekygen comment: 
warning in ..., line 1: Discarded extraneous Zeekygen comment: Zeek Processing. Matches the Types from Spicy (exported .evt) to zeek (types.zeek)
warning in ..., line 1: Discarded extraneous Zeekygen comment: 
warning in ..., line 1: Discarded extraneous Zeekygen comment: 
warning in ..., line 1: Discarded extraneous Zeekygen comment: Author:   Taegan Williams
warning in ..., line 1: Discarded extraneous Zeekygen comment: Contact:  taegan.williams@inl.gov
warning in ..., line 1: Discarded extraneous Zeekygen comment: 
warning in ..., line 1: Discarded extraneous Zeekygen comment: Copyright (c) 2024 Battelle Energy Alliance, LLC.  All rights reserved.
```

If you read the file I linked, it talks about the difference between `#`, `##`, and `##!` comments.

This commit changes the `##` comments at the beginning of the file to `##!` comments.