### PR TITLE
replace 'std::string' with 'hilti::rt::String' for spicy 1.16 and fix incorrect random_device use

### DIFF
--- a/analyzer/ge_srtp_functions.cc
+++ b/analyzer/ge_srtp_functions.cc
@@ -10,23 +10,31 @@
 namespace GE_SRTP_FUNCTIONS
 {
     #define ID_LEN 9
-    
-    hilti::rt::String generateId() {
+
+    // Spicy exports its version in `PROJECT_VERSION_NUMBER`.
+    // hilti::rt::String was introduced in HILTI 1.16 (Zeek 8.2.1); on
+    // earlier versions (e.g. Zeek 8.0.9 / HILTI 1.14.2) it doesn't exist,
+    // so fall back to std::string there.
+#if PROJECT_VERSION_NUMBER >= 11600
+    using SpicyString = hilti::rt::String;
+#else
+    using SpicyString = std::string;
+#endif
+
+    SpicyString generateId() {
+        static std::random_device rd;
+        static std::mt19937 gen(rd());
+        static std::uniform_int_distribution<> dis(0, 255);
+
         std::stringstream ss;
         for (auto i = 0; i < ID_LEN; i++) {
             // Generate a random char
-            std::random_device rd;
-            std::mt19937 gen(rd());
-            std::uniform_int_distribution<> dis(0, 255);
             const auto rc = dis(gen);
-
             // Hex representaton of random char
             std::stringstream hexstream;
             hexstream << std::hex << rc;
             auto hex = hexstream.str();
             ss << (hex.length() < 2 ? '0' + hex : hex);
         }
-        return ss.str();
+        return {ss.str()};
     }
-}
-

--- a/analyzer/ge_srtp_functions.cc
+++ b/analyzer/ge_srtp_functions.cc
@@ -38,3 +38,4 @@ namespace GE_SRTP_FUNCTIONS
         }
         return {ss.str()};
     }
+}

--- a/analyzer/ge_srtp_functions.cc
+++ b/analyzer/ge_srtp_functions.cc
@@ -11,8 +11,8 @@ namespace GE_SRTP_FUNCTIONS
 {
     #define ID_LEN 9
     
-    std::string generateId() {
-        std::stringstream ss;
+    hilti::rt::String generateId() {
+        hilti::rt::Stringstream ss;
         for (auto i = 0; i < ID_LEN; i++) {
             // Generate a random char
             std::random_device rd;
@@ -21,7 +21,7 @@ namespace GE_SRTP_FUNCTIONS
             const auto rc = dis(gen);
 
             // Hex representaton of random char
-            std::stringstream hexstream;
+            hilti::rt::Stringstream hexstream;
             hexstream << std::hex << rc;
             auto hex = hexstream.str();
             ss << (hex.length() < 2 ? '0' + hex : hex);

--- a/analyzer/ge_srtp_functions.cc
+++ b/analyzer/ge_srtp_functions.cc
@@ -12,7 +12,7 @@ namespace GE_SRTP_FUNCTIONS
     #define ID_LEN 9
     
     hilti::rt::String generateId() {
-        hilti::rt::Stringstream ss;
+        std::stringstream ss;
         for (auto i = 0; i < ID_LEN; i++) {
             // Generate a random char
             std::random_device rd;
@@ -21,7 +21,7 @@ namespace GE_SRTP_FUNCTIONS
             const auto rc = dis(gen);
 
             // Hex representaton of random char
-            hilti::rt::Stringstream hexstream;
+            std::stringstream hexstream;
             hexstream << std::hex << rc;
             auto hex = hexstream.str();
             ss << (hex.length() < 2 ? '0' + hex : hex);


### PR DESCRIPTION
According to bbannier on the Zeek Slack:

> As for the undefined symbols you are seeing, spicy-1.16 [changed how Spicy string values are passed](https://github.com/zeek/spicy/blob/72b27c93eb8f32d60cf09555c0bfd20cebcadc70/NEWS.rst?plain=1#L66-L67). The fix should be to swap `std::string` uses out for `hilti::rt::String`.

This commit replaces `std::string` with `hilti::rt::String` to fix undefined symbol errors found at runtime with spicy 1.16 in Zeek 8.2.1.